### PR TITLE
fix: rimuovi doppi spazi nell'HTML dei pulsanti e aggiorna link downl…

### DIFF
--- a/FE-Utility.user.js
+++ b/FE-Utility.user.js
@@ -257,12 +257,11 @@
         p.innerHTML =
             '<div id="FEPlugin_TopRow">' +
                 '<span id="FEPlugin_Logo">&#128196; FE-Utility v' + VERSION + '</span>' +
-                '<button class="fepBtn fep-green"  id="btn_scaricaFE">&#11015; Scarica fatture</button>' +
-                '<button class="fepBtn fep-blue"   id="btn_migliora">&#128202; Fatture &#8594; Excel</button>' +
-                
+                '<button class="fepBtn fep-green" id="btn_scaricaFE">&#11015; Scarica fatture</button>' +
+                '<button class="fepBtn fep-blue" id="btn_migliora">&#128202; Fatture &#8594; Excel</button>' +
                 '<button class="fepBtn fep-orange" id="btn_corrispettivi">&#128200; Corrispettivi &#8594; Excel</button>' +
-                '<button class="fepBtn fep-grey"   id="btn_datePicker">&#128197; Date</button>' +
-                '<button class="fepBtn fep-red"    id="btn_stop" style="display:none!important">&#9209; Stop</button>' +
+                '<button class="fepBtn fep-grey" id="btn_datePicker">&#128197; Date</button>' +
+                '<button class="fepBtn fep-red" id="btn_stop" style="display:none!important">&#9209; Stop</button>' +
                 '<span style="all:initial!important;flex:1 1 auto!important;min-width:10px!important;"></span>' +
                 '<a id="FEPlugin_InfoLink" href="' + INSTRUCTIONS_URL + '" target="_blank" rel="noopener noreferrer" title="Istruzioni FE-Utility">&#8505;&#65039;</a>' +
                 '<button id="FEPlugin_X" style="all:initial;display:inline-flex;align-items:center;' +

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Userscript per Tampermonkey / Greasemonkey che aggiunge una barra degli strument
 > Richiede **Tampermonkey** (Chrome/Edge/Firefox) o **Greasemonkey** (Firefox)
 
 1. Installa l'estensione del browser:
-   - [Tampermonkey per Chrome](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo)
+   - [Tampermonkey per Chrome](https://chromewebstore.google.com/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo)
+   - [Tampermonkey per Edge](https://microsoftedge.microsoft.com/addons/detail/tampermonkey/iikmkjmpaadaobahmlepeloendndfphd)
    - [Tampermonkey per Firefox](https://addons.mozilla.org/it/firefox/addon/tampermonkey/)
    - [Greasemonkey per Firefox](https://addons.mozilla.org/it/firefox/addon/greasemonkey/)
 

--- a/index.html
+++ b/index.html
@@ -627,7 +627,8 @@
                         <h4>Installa l'estensione del browser</h4>
                         <p>Scegli l'estensione per il tuo browser:</p>
                         <p>
-                            <a href="https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo" target="_blank">Tampermonkey per Chrome/Edge</a> ·
+                            <a href="https://chromewebstore.google.com/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo" target="_blank">Tampermonkey per Chrome</a> ·
+                            <a href="https://microsoftedge.microsoft.com/addons/detail/tampermonkey/iikmkjmpaadaobahmlepeloendndfphd" target="_blank">Tampermonkey per Edge</a> ·
                             <a href="https://addons.mozilla.org/it/firefox/addon/tampermonkey/" target="_blank">Tampermonkey per Firefox</a> ·
                             <a href="https://addons.mozilla.org/it/firefox/addon/greasemonkey/" target="_blank">Greasemonkey per Firefox</a>
                         </p>


### PR DESCRIPTION
…oad Tampermonkey

- FE-Utility.user.js: rimosse doppie/triple spaziature tra attributi class e id nei pulsanti della toolbar e rimossa la riga vuota con soli spazi nel blocco di concatenazione stringhe (linea 262)
- index.html: link Tampermonkey Chrome/Edge separati in due voci distinte; URL Chrome aggiornato al nuovo formato chromewebstore.google.com; aggiunto link Edge Add-ons (microsoftedge.microsoft.com)
- README.md: aggiunto link "Tampermonkey per Edge"; URL Chrome aggiornato al nuovo formato chromewebstore.google.com
